### PR TITLE
Replace trending repositories name selector

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -73,7 +73,7 @@ export class Scraper {
     scrapeTrendingRepos(lang_name: string) {
         return this.fetchTrendPage(lang_name).then((html: string) => {
             const dom = cheerio.load(html);
-            return dom(".repo-list-item .repo-list-name a")
+            return dom(".repo-list h3 a")
                             .toArray()
                             .map((a: any) => {
                                 const href: string = a.attribs["href"];


### PR DESCRIPTION
I was trying to use this library, but unfortunately it does not work.  I think it's because of parsing problem

currently https://github.com/trending - page does not have `.repo-list-item .repo-list-name a` selector  (at least I can't inspect it) .

So I have changed locally  with `.repo-list h3 a` and it's worked in following case

```
var Trending = require("github-trend");
var scraper = new Trending.Scraper();

scraper.scrapeTrendingRepos("").then(function (repos) {
        repos.forEach(function (repo) {
            console.log(repo.owner);
            console.log(repo.name);
        });
        res.send('Got repos ' + JSON.stringify(repos));
 }).catch(function (err) {
        console.log(err.message);
 });
```